### PR TITLE
Added methods to Hologram to improve changing the lines

### DIFF
--- a/holoeasy-core/src/main/java/org/holoeasy/hologram/Hologram.java
+++ b/holoeasy-core/src/main/java/org/holoeasy/hologram/Hologram.java
@@ -19,7 +19,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
 public class Hologram {
-
     private final HoloEasy lib;
     private final PrivateConfig pvt;
     private final UUID id = UUID.randomUUID();
@@ -168,12 +167,18 @@ public class Hologram {
     }
 
     public void updateLines() {
-        lines.forEach(Line::updateAll);
+        for (Line<?> line : lines) {
+            line.updateAll();
+        }
     }
 
     public void replaceLines(@NotNull List<? extends Line<?>> newLines) {
         // hide current lines from all players
-        pvt.getSeeingPlayers().forEach(player -> lines.forEach(line -> line.hide(player)));
+        for (Player player : pvt.getSeeingPlayers()) {
+            for (Line<?> line : lines) {
+                line.hide(player);
+            }
+        }
 
         lines.clear();
         loaded = false;
@@ -181,7 +186,11 @@ public class Hologram {
         pvt.updateLinesLocation();
 
         // show new lines to all players
-        pvt.getSeeingPlayers().forEach(player -> lines.forEach(line -> line.show(player)));
+        for (Player player : pvt.getSeeingPlayers()) {
+            for (Line<?> line : lines) {
+                line.show(player);
+            }
+        }
     }
 
     @Override

--- a/holoeasy-core/src/main/java/org/holoeasy/hologram/Hologram.java
+++ b/holoeasy-core/src/main/java/org/holoeasy/hologram/Hologram.java
@@ -37,61 +37,61 @@ public class Hologram {
         this(lib, location, null, null);
     }
 
-    public HoloEasy getLib() {
+    public @NotNull HoloEasy getLib() {
         return lib;
     }
 
     @ApiStatus.Internal
-    public PrivateConfig getPvt() {
+    public @NotNull PrivateConfig getPvt() {
         return pvt;
     }
 
-    public UUID getId() {
+    public @NotNull UUID getId() {
         return id;
     }
 
-    public Location getLocation() {
+    public @NotNull Location getLocation() {
         return location;
     }
 
-    public List<Line<?>> getLines() {
+    public @NotNull List<Line<?>> getLines() {
         return lines;
     }
 
-    protected BlockLine blockLine(@NotNull Function<Player, ItemStack> blockSupplier) {
+    protected @NotNull BlockLine blockLine(@NotNull Function<@NotNull Player, @NotNull ItemStack> blockSupplier) {
         BlockLine line = new BlockLine(this, blockSupplier);
         lines.add(line);
         return line;
     }
 
-    protected ItemLine itemLine(@NotNull Function<Player, ItemStack> itemSupplier) {
+    protected @NotNull ItemLine itemLine(@NotNull Function<@NotNull Player, @NotNull ItemStack> itemSupplier) {
         ItemLine line = new ItemLine(this, itemSupplier);
         lines.add(line);
         return line;
     }
 
-    protected TextLine textLine(@NotNull Function<Player, String> textSupplier) {
+    protected @NotNull TextLine textLine(@NotNull Function<@NotNull Player, @NotNull String> textSupplier) {
         TextLine line = new TextLine(this, textSupplier);
         lines.add(line);
         return line;
     }
 
     @ApiStatus.Experimental
-    protected DisplayTextLine displayTextLine(@NotNull Function<Player, String> textSupplier) {
+    protected @NotNull DisplayTextLine displayTextLine(@NotNull Function<@NotNull Player, @NotNull String> textSupplier) {
         DisplayTextLine line = new DisplayTextLine(this, textSupplier);
         lines.add(line);
         return line;
     }
 
     @ApiStatus.Experimental
-    protected DisplayBlockLine displayBlockLine(@NotNull Function<Player, Material> materialSupplier) {
+    protected @NotNull DisplayBlockLine displayBlockLine(@NotNull Function<@NotNull Player, @NotNull Material> materialSupplier) {
         DisplayBlockLine line = new DisplayBlockLine(this, materialSupplier);
         lines.add(line);
         return line;
     }
 
     @ApiStatus.Experimental
-    protected InteractionLine interactionLine() {
+    protected @NotNull InteractionLine interactionLine() {
         InteractionLine line = new InteractionLine(this);
         lines.add(line);
         return line;
@@ -117,18 +117,18 @@ public class Hologram {
         }
     }
 
-    public boolean isShownFor(Player player) {
+    public boolean isShownFor(@NotNull Player player) {
         return pvt.getSeeingPlayers().contains(player);
     }
 
-    public <T extends Hologram> void show(IHologramPool<T> pool) {
+    public <T extends Hologram> void show(@NotNull IHologramPool<T> pool) {
         if (pool.getHolograms().stream().anyMatch(h -> h.getId().equals(this.id))) {
             throw new KeyAlreadyExistsException(this.id);
         }
         pool.getHolograms().add((T) this);
     }
 
-    public void show(Player player) {
+    public void show(@NotNull Player player) {
         if (!loaded) {
             if(lines.isEmpty()) {
                 throw new IllegalStateException("Cannot show hologram with no lines.");
@@ -147,7 +147,7 @@ public class Hologram {
         }
     }
 
-    public void hide(Player player) {
+    public void hide(@NotNull Player player) {
         for (Line<?> line : lines) {
             (line).hide(player);
         }
@@ -158,13 +158,30 @@ public class Hologram {
         }
     }
 
-    public void hide(IHologramPool<?> pool) {
+    public void hide(@NotNull IHologramPool<?> pool) {
         boolean removed = pool.getHolograms().remove(this);
         if (removed) {
             for (Player player : pvt.getSeeingPlayers()) {
                 hide(player);
             }
         }
+    }
+
+    public void updateLines() {
+        lines.forEach(Line::updateAll);
+    }
+
+    public void replaceLines(@NotNull List<? extends Line<?>> newLines) {
+        // hide current lines from all players
+        pvt.getSeeingPlayers().forEach(player -> lines.forEach(line -> line.hide(player)));
+
+        lines.clear();
+        loaded = false;
+        lines.addAll(newLines);
+        pvt.updateLinesLocation();
+
+        // show new lines to all players
+        pvt.getSeeingPlayers().forEach(player -> lines.forEach(line -> line.show(player)));
     }
 
     @Override


### PR DESCRIPTION
Hey. First of all thanks for adding the per-player function to the lines. That was a great addition. 

I however found that if I ever want to replace the amount of lines in a hologram it starts getting a bit messy and I wasn't really able to do it. If the amount of lines were the same I could just use the function and update the lines to whatever I need but what if the amount is different? I start with 2 lines and then I need to update to 3 lines with different text.

So in this commit I've address this issue of mine and also just added few @NotNull for better API clarity.

Now, I'm not considering this to be a final version. While I tested it and it seems to work I'd definitely want at least an opinion of one other person first and him testing it as well.

This is how the usage would look. I'm also wondering if we can add default offset and just keep it optional if someone wants it different?

<details>
  <summary>Usage example</summary>
  
  ```java
public class PetEggHologram extends Hologram {
    private static final IHologramPool<PetEggHologram> POOL = MLPSkyblock.INSTANCE.getHoloEasy().startPool(100, false);

    private final @NotNull PetEggInstance petEggInstance;

    public PetEggHologram(@NotNull PetEggInstance petEggInstance) {
        super(
                MLPSkyblock.INSTANCE.getHoloEasy(),
                petEggInstance.getMob().getLocation().clone()
        );
        this.petEggInstance = petEggInstance;

        this.initialize();
        this.show(POOL);
    }

    private void initialize() {
        this.getLines().addAll(this.getNewLines());
    }

    private List<TextLine> getNewLines() {
        final List<String> hatchedLines = PetConfig.Egg.Hologram.HATCHING.getValue();
        final List<String> readyLines = PetConfig.Egg.Hologram.READY.getValue();

        final AtomicDouble offsetCounter = new AtomicDouble(0);
        final long timeLeftSec = (this.petEggInstance.getPetEgg().hatchTimestamp() - System.currentTimeMillis()) / 1000;
        if (timeLeftSec > 0) {
            return hatchedLines.stream()
                    .map(str -> new TextLine(
                                    this,
                                    player -> ColorUtils.toColoredLegacy(
                                            str.replace("<time>", TimeUtils.formatTime(
                                                    (this.petEggInstance.getPetEgg().hatchTimestamp() - System.currentTimeMillis()) / 1000
                                            ))
                                    )
                            ).yOffset(offsetCounter.getAndAdd(-0.25))
                    )
                    .toList();
        } else {
            return readyLines.stream()
                    .map(str -> new TextLine(
                                    this,
                                    player -> ColorUtils.toColoredLegacy(str)
                            ).yOffset(offsetCounter.getAndAdd(-0.25))
                    )
                    .toList();
        }
    }

    public void update() {
        this.replaceLines(this.getNewLines());
    }
}
```
</details>


I'm also thinking if this can be done in a better and more customizable way or if this is enough? Just looking for a feedback first. I'm happy to do any changes needed as I use this util in all my projects so I'm only happy to give back some of the time the existence of this has saved me.